### PR TITLE
Update soybean.yaml

### DIFF
--- a/soybean.yaml
+++ b/soybean.yaml
@@ -339,7 +339,7 @@ CropParameters:
             #
             # ROOTING DEPTH
             #
-            RDI:
+            ROOTDI:
             -  10.0
             - initial rooting depth
             - ['cm']


### PR DESCRIPTION
I have made a slight change to the rooting depth. I changed the abbreviations for initial rooting depth from RDI to ROOTDI. The change should fix the error returned [ParameterError: Value for parameter ROOTDI missing] when I run the Lintul3 model for nutrient-limited yield simulation.
 
   # ROOTING DEPTH
            #
            ROOTDI:
            -  10.0
            - initial rooting depth
            - ['cm']